### PR TITLE
Fixed the borders button to refer to the correct map link (map.civinfo.net)

### DIFF
--- a/src/comptime.ts
+++ b/src/comptime.ts
@@ -27,5 +27,5 @@ export function getActChangeColours(
 export function getBordersLink(
     astro: AstroGlobal
 ) {
-    return "https://civmc-map.github.io/#url=" + astro.url.origin + "/government/borders.json"
+    return "https://map.civinfo.net/#url=" + astro.url.origin + "/government/borders.json"
 }


### PR DESCRIPTION
The current top bar borders button leads to the older site which doesn't show the borders.