### PR TITLE
Set CNAME in deployment workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,6 +156,7 @@ jobs:
         with:
           target_branch: gh-pages
           build_dir: dist
+          fqdn: icenia.org
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Fixes custom domain config being overwritten after every deployment